### PR TITLE
Ookla repositories appear to have moved

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN true &&\
 \
 # Install dependencies
 apt-get update && \
-apt-get -q -y install --no-install-recommends apt-utils gnupg1 apt-transport-https dirmngr && \
+apt-get -q -y install --no-install-recommends apt-utils gnupg1 apt-transport-https dirmngr curl && \
 \
 # Install Python packages
 pip3 install pythonping influxdb && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,8 @@ ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # Install speedtest-cli
 if [ ! -e /usr/bin/speedtest ]
 then
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
-  echo "deb https://ookla.bintray.com/debian buster main" | tee  /etc/apt/sources.list.d/speedtest.list
+  curl -L "https://packagecloud.io/ookla/speedtest-cli/gpgkey" 2> /dev/null | apt-key add -
+  echo "deb https://packagecloud.io/ookla/speedtest-cli/debian/ buster main" | tee  /etc/apt/sources.list.d/ookla_speedtest-cli.list
   apt-get update && apt-get -q -y install speedtest
   apt-get -q -y autoremove && apt-get -q -y clean
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request updates the ookla repositories to use packagecloud instead of bintray. My container was broken on restart (the speedtest CLI wouldn't install). This updates the repositories and is working for me.